### PR TITLE
Temporary fixes

### DIFF
--- a/1.1/Patches/AtlasMaterials/Patch.xml
+++ b/1.1/Patches/AtlasMaterials/Patch.xml
@@ -2,7 +2,7 @@
 
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>[1.0] Atlas' Materials</li>
+            <li>Materials+</li>
         </mods>
         <match Class="PatchOperationSequence">
             <success>Always</success>

--- a/1.1/Patches/KurasExtraStones/Patch.xml
+++ b/1.1/Patches/KurasExtraStones/Patch.xml
@@ -2,7 +2,7 @@
 
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>Kura's Extra Stone</li>
+            <li>[K]Extra Stone</li>
         </mods>
         <match Class="PatchOperationSequence">
             <success>Always</success>

--- a/1.1/Patches/MechalitCore/Patch.xml
+++ b/1.1/Patches/MechalitCore/Patch.xml
@@ -2,7 +2,7 @@
 
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>Mechalit Core 1.0</li>
+            <li>Mechalit Core 1.1</li>
         </mods>
         <match Class="PatchOperationSequence">
             <success>Always</success>

--- a/1.1/Patches/Quarry/Patch.xml
+++ b/1.1/Patches/Quarry/Patch.xml
@@ -2,7 +2,7 @@
 
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>Quarry</li>
+            <li>Quarry 1.1</li>
         </mods>
         <match Class="PatchOperationAddModExtension">
             <xpath>/Defs/WorkGiverDef[defName="QRY_MineQuarry"]</xpath>

--- a/Source/SurvivalTools/StaticConstructorClass.cs
+++ b/Source/SurvivalTools/StaticConstructorClass.cs
@@ -90,6 +90,7 @@ namespace SurvivalTools
                     return retVal;
                 }))
             {
+                if (stuff.modContentPack == null) continue;
                 string newLine = $"{stuff} ({stuff.modContentPack.Name})";
                 if (stuff.HasModExtension<StuffPropsTool>())
                     hasPropsBuilder.AppendLine(newLine);


### PR DESCRIPTION
None of them are tested. I've just updated the names of the mods that changed with 1.1.
I've just confirmed Mechalit core works
The following are not up for 1.1 or I couldn't understand where it came from:
- Crystalloid
- RimsenalFederation

Edit: added temporary null check to constructor